### PR TITLE
Change unit of "bone_x" from "%" to "kg"

### DIFF
--- a/components/medisana_bs444/sensor.py
+++ b/components/medisana_bs444/sensor.py
@@ -86,8 +86,8 @@ for x in range(1, 8):
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional("%s_%s" %(CONF_BONE,x)): sensor.sensor_schema(
-                unit_of_measurement=UNIT_PERCENT,
-                icon=ICON_PERCENT,
+                unit_of_measurement=UNIT_KILOGRAM,
+                icon=ICON_SCALE_BATHROOM,
                 accuracy_decimals=1,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),

--- a/components/medisana_bs444/sensor.py
+++ b/components/medisana_bs444/sensor.py
@@ -55,12 +55,6 @@ for x in range(1, 8):
                 accuracy_decimals=1,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
-            cv.Optional("%s_%s" %(CONF_BMI,x)): sensor.sensor_schema(
-                unit_of_measurement=UNIT_EMPTY,
-                icon=ICON_SCALE_BATHROOM,
-                accuracy_decimals=1,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
             cv.Optional("%s_%s" %(CONF_KILOCALORIERS,x)): sensor.sensor_schema(
                 unit_of_measurement=UNIT_KILOCALORIERS,
                 icon=ICON_EMPTY,


### PR DESCRIPTION
The unit of the bone value should be "kg", not "%".
This PR changes that and additionally removes a double "BMI" configuration ins sensor.py.

Applying this change will make homeassistant (or the Spook-Extension?) to show a dialog to change the units for all saved data, so nothing should be lost (which someone should test before ;-) )
