### PR TITLE
Add on_user_metrics_updated automation trigger

### DIFF
--- a/components/medisana_bs444/Scale.h
+++ b/components/medisana_bs444/Scale.h
@@ -81,5 +81,32 @@ namespace esphome
       std::string toString() const;
       static Body decode(const uint8_t *values, bool useTimeoffset);
     };
+
+    /// Struct containing all measurement data for a user, passed to on_user_metrics_updated trigger
+    struct UserMeasurement
+    {
+      uint8_t user_id{0}; // 1-8
+
+      // Person data
+      uint8_t age{0};
+      float size{0}; // in meters
+      bool is_male{false};
+      bool high_activity{false};
+
+      // Weight data
+      float weight{0};
+      float bmi{0};
+      bool has_weight{false};
+
+      // Body composition
+      uint32_t kcal{0};
+      float fat{0};
+      float tbw{0};
+      float muscle{0};
+      float bone{0};
+      bool has_body{false};
+
+      time_t timestamp{0};
+    };
   } // namespace medisana_bs444
 } // namespace esphome

--- a/components/medisana_bs444/__init__.py
+++ b/components/medisana_bs444/__init__.py
@@ -1,5 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
+from esphome import automation
 from esphome.components import (
     ble_client,
     time,
@@ -7,9 +8,11 @@ from esphome.components import (
 from esphome.const import (
     CONF_ID,
     CONF_TIME_ID,
+    CONF_TRIGGER_ID,
 )
 
 CONF_TIME_OFFSET = "timeoffset"
+CONF_ON_USER_METRICS_UPDATED = "on_user_metrics_updated"
 
 AUTO_LOAD = [
     "sensor", "binary_sensor"
@@ -29,12 +32,23 @@ MedisanaBS444 = medisana_bs444_ns.class_(
     "MedisanaBS444", ble_client.BLEClientNode, cg.Component
 )
 
+UserMeasurement = medisana_bs444_ns.struct("UserMeasurement")
+UserMeasurementConstRef = UserMeasurement.operator("ref").operator("const")
+UserMetricsUpdatedTrigger = medisana_bs444_ns.class_(
+    "UserMetricsUpdatedTrigger", automation.Trigger.template(UserMeasurementConstRef)
+)
+
 CONFIG_SCHEMA = (
     ble_client.BLE_CLIENT_SCHEMA.extend(
         {
             cv.GenerateID(): cv.declare_id(MedisanaBS444),
             cv.GenerateID(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
             cv.Optional(CONF_TIME_OFFSET, default=True): cv.boolean,
+            cv.Optional(CONF_ON_USER_METRICS_UPDATED): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(UserMetricsUpdatedTrigger),
+                }
+            ),
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -48,4 +62,8 @@ async def to_code(config):
         time_ = await cg.get_variable(config[CONF_TIME_ID])
         cg.add(var.set_time_id(time_))
     cg.add(var.use_timeoffset(config[CONF_TIME_OFFSET]))
+
+    for conf in config.get(CONF_ON_USER_METRICS_UPDATED, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [(UserMeasurementConstRef, "x")], conf)
 

--- a/components/medisana_bs444/medisanabs444.h
+++ b/components/medisana_bs444/medisanabs444.h
@@ -3,6 +3,7 @@
 #ifdef USE_ESP32
 
 #include "esphome/core/component.h"
+#include "esphome/core/automation.h"
 
 #include "esphome/components/sensor/sensor.h"
 #ifdef USE_BINARY_SENSOR
@@ -124,6 +125,25 @@ namespace esphome
 
     private:
       u_int32_t registered_notifications_ = 0;
+
+    public:
+      void add_on_user_metrics_updated_callback(std::function<void(const UserMeasurement &)> callback)
+      {
+        this->user_metrics_updated_callback_.add(std::move(callback));
+      }
+
+    protected:
+      CallbackManager<void(const UserMeasurement &)> user_metrics_updated_callback_;
+    };
+
+    class UserMetricsUpdatedTrigger : public Trigger<const UserMeasurement &>
+    {
+    public:
+      explicit UserMetricsUpdatedTrigger(MedisanaBS444 *parent)
+      {
+        parent->add_on_user_metrics_updated_callback([this](const UserMeasurement &measurement)
+                                                     { this->trigger(measurement); });
+      }
     };
   } // namespace medisana_bs444
 } // namespace esphome


### PR DESCRIPTION
## Summary
- Adds `on_user_metrics_updated` trigger that fires after all metrics for a user are published
- Provides access to all measurement data in automations (weight, BMI, body composition, etc.)
- Enables use with lambdas, HTTP requests, or Home Assistant events

## Usage Example

```yaml
medisana_bs444:
  ble_client_id: my_ble_client
  on_user_metrics_updated:
    - lambda: |-
        ESP_LOGI("scale", "User %d: %.1f kg, BMI %.1f", 
                 x.user_id, x.weight, x.bmi);
    - http_request.post:
        url: "http://myserver/api/weight"
        json: |-
          root["user"] = x.user_id;
          root["weight"] = x.weight;
          root["bmi"] = x.bmi;
          root["fat"] = x.fat;
```

## Available Fields
| Field | Type | Description |
|-------|------|-------------|
| `user_id` | uint8 | User 1-8 |
| `weight` | float | Weight in kg |
| `bmi` | float | Calculated BMI |
| `kcal` | uint32 | Kcal |
| `fat` | float | Fat % |
| `tbw` | float | Total body water % |
| `muscle` | float | Muscle % |
| `bone` | float | Bone weight |
| `age` | uint8 | Age |
| `size` | float | Height in meters |
| `is_male` | bool | Gender |
| `high_activity` | bool | Activity level |
| `has_weight` | bool | Weight data available |
| `has_body` | bool | Body composition available |
| `timestamp` | time_t | Measurement timestamp |

## Test plan
- [x] Verify component compiles with ESPHome
- [x] Test trigger fires after measurement with correct data
- [x] Test lambda access to all fields
- [ ] Test with http_request action